### PR TITLE
Language code in url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ To translate, do the following steps:
 
 - Create language files with ```python manage.py makemessages -l ru_RU``` where ```ru_RU``` - your language's code (that's actually Russian's language code);
 - Create JavaScript language files with ```python manage.py makemessages -d djangojs -l ru_RU``` where ```ru_RU``` - your language's code;
-- Add language code and it's original name to ```LANGUAGES``` variable in ```project/settings.py```;
+- Add language code and it's original name to ```LANGUAGES``` and short code to ```LANGUAGES_SHORT_CODES``` variables in ```project/settings.py```;
 - Create admin account by typing ```python manage.py createsuperuser```;
 - Start server by ```python manage.py runserver```;
 - Log in admin account on ```localhost:8000/admin/```;

--- a/app/templates/sitemap.xml
+++ b/app/templates/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="2.0" encoding="UTF-8"?>
 <urlset
       xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -6,37 +6,67 @@
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
 <!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
 
-
 <url>
   <loc>https://ascii-generator.site/</loc>
-  <lastmod>2020-09-18T18:07:36+00:00</lastmod>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
   <loc>https://ascii-generator.site/t/</loc>
-  <lastmod>2020-09-18T18:07:36+00:00</lastmod>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
   <priority>0.90</priority>
 </url>
 <url>
   <loc>https://ascii-generator.site/about/</loc>
-  <lastmod>2020-09-18T18:07:36+00:00</lastmod>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
   <loc>https://ascii-generator.site/feedback/</loc>
-  <lastmod>2020-09-18T18:07:36+00:00</lastmod>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
   <priority>0.70</priority>
 </url>
 <url>
   <loc>https://ascii-generator.site/policy/privacy/</loc>
-  <lastmod>2020-09-18T18:07:36+00:00</lastmod>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
   <priority>0.60</priority>
 </url>
 <url>
   <loc>https://ascii-generator.site/policy/cookie/</loc>
-  <lastmod>2020-09-18T18:07:36+00:00</lastmod>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
   <priority>0.60</priority>
 </url>
 
+<!-- Same but with russian language links -->
+<url>
+  <loc>https://ascii-generator.site/ru/</loc>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://ascii-generator.site/ru/t/</loc>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
+  <priority>0.90</priority>
+</url>
+<url>
+  <loc>https://ascii-generator.site/ru/about/</loc>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://ascii-generator.site/ru/feedback/</loc>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
+  <priority>0.70</priority>
+</url>
+<url>
+  <loc>https://ascii-generator.site/ru/policy/privacy/</loc>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
+  <priority>0.60</priority>
+</url>
+<url>
+  <loc>https://ascii-generator.site/ru/policy/cookie/</loc>
+  <lastmod>2020-11-18T18:07:36+00:00</lastmod>
+  <priority>0.60</priority>
+</url>
 
 </urlset>

--- a/project/settings.py
+++ b/project/settings.py
@@ -71,6 +71,8 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'staff.middleware.RestrictStaffToAdminMiddleware',  # Restrict staff to admin page
     'django.middleware.locale.LocaleMiddleware',
+    # If language code is in url - set desired language and redirect to the same but normal url without lang code
+    'app.middleware.LanguageURLRedirectMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -152,9 +154,11 @@ LOCALE_PATHS = (
 
 LANGUAGE_CODE = 'en-us'
 
+LANGUAGES_SHORT_CODES = ('en', 'ru',)
+
 LANGUAGES = (
     ('en-us', 'English'),
-    ('ru-RU', 'Русский')
+    ('ru-RU', 'Русский'),
 )
 
 TIME_ZONE = 'UTC'


### PR DESCRIPTION
Language code can be specified in url, for example: "ascii-generator.site/ru/about/". It will activate specified language and redirect to: "ascii-generator.site/about/" without actual language in url. Made for SEO.