### PR TITLE
"is_hidden" and "url_code" fields fixed, admin page updated

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import mark_safe
 
 from app.models import (
     Feedback, GeneratedASCII,
@@ -7,10 +9,86 @@ from app.models import (
 )
 
 
-admin.site.register(Feedback)
-admin.site.register(GeneratedASCII)
-admin.site.register(ImageToASCIIType)
-admin.site.register(ImageToASCIIOptions)
-admin.site.register(TextToASCIIType)
-admin.site.register(OutputASCII)
-admin.site.register(Report)
+class GeneratedASCIIAdmin(admin.ModelAdmin):
+    def text_to_ascii_type_link(self, obj):
+        link = reverse('admin:app_texttoasciitype_change', args=[obj.text_to_ascii_type.id])
+        return mark_safe(f'<a href="{link}">Open</a>')
+    text_to_ascii_type_link.short_description = 'Text to ASCII type'
+
+    def image_to_ascii_type_link(self, obj):
+        link = reverse('admin:app_imagetoasciitype_change', args=[obj.image_to_ascii_type.id])
+        return mark_safe(f'<a href="{link}">Open</a>')
+    image_to_ascii_type_link.short_description = 'Image to ASCII type'
+
+    search_fields = (
+        'url_code',
+    )
+
+    readonly_fields = (
+        'text_to_ascii_type_link',
+        'image_to_ascii_type_link',
+        'url_code',
+        'date_shared',
+    )
+
+
+admin.site.register(GeneratedASCII, GeneratedASCIIAdmin)
+
+
+class FeedbackAdmin(admin.ModelAdmin):
+    readonly_fields = (
+        'date',
+    )
+
+
+admin.site.register(Feedback, FeedbackAdmin)
+
+
+class ImageToASCIITypeAdmin(admin.ModelAdmin):
+    def image_to_ascii_options_link(self, obj):
+        link = reverse('admin:app_imagetoasciioptions_change', args=[obj.options.id])
+        return mark_safe(f'<a href="{link}">Open</a>')
+    image_to_ascii_options_link.short_description = 'Options'
+
+    raw_id_fields = ('generated_ascii',)
+
+    readonly_fields = (
+        'image_to_ascii_options_link',
+    )
+
+
+admin.site.register(ImageToASCIIType, ImageToASCIITypeAdmin)
+
+
+class ImageToASCIIOptionsAdmin(admin.ModelAdmin):
+    raw_id_fields = ('image_to_ascii_type',)
+
+
+admin.site.register(ImageToASCIIOptions, ImageToASCIIOptionsAdmin)
+
+
+class TextToASCIITypeAdmin(admin.ModelAdmin):
+    raw_id_fields = ('generated_ascii',)
+
+
+admin.site.register(TextToASCIIType, TextToASCIITypeAdmin)
+
+
+class OutputASCIIAdmin(admin.ModelAdmin):
+    search_fields = ('generated_ascii__url_code',)
+    raw_id_fields = ('generated_ascii',)
+
+
+admin.site.register(OutputASCII, OutputASCIIAdmin)
+
+
+class ReportAdmin(admin.ModelAdmin):
+    search_fields = ('generated_ascii__url_code',)
+    raw_id_fields = ('generated_ascii',)
+
+    readonly_fields = (
+        'date_reported',
+    )
+
+
+admin.site.register(Report, ReportAdmin)

--- a/app/models.py
+++ b/app/models.py
@@ -32,7 +32,8 @@ class GeneratedASCII(models.Model):
         return 'GeneratedASCII: ' + self.url_code
 
     def save(self, *args, **kwargs):
-        self.url_code = self.generate_random_unique_url_code()
+        if not self.url_code:
+            self.url_code = self.generate_random_unique_url_code()
         super().save(*args, **kwargs)
 
     def generate_random_unique_url_code(self):

--- a/app/services.py
+++ b/app/services.py
@@ -81,7 +81,7 @@ class GeneratedASCIIService:
         return full_path, full_name
 
     @staticmethod
-    def get_object_or_404(ascii_url_code) -> GeneratedASCII:
+    def get_active_object_or_404(ascii_url_code) -> GeneratedASCII:
         # find it in cache, if not found - set it
         key = f'GeneratedASCIIService_get_object_or_404_{ascii_url_code}'
         generated_ascii = cache.get(key)
@@ -95,6 +95,9 @@ class GeneratedASCIIService:
                 cache.set(key, generated_ascii)
             except GeneratedASCII.DoesNotExist:
                 raise Http404
+        # we don't want to return hidden object
+        if generated_ascii.is_hidden:
+            raise Http404
 
         return generated_ascii
 

--- a/app/tests.py
+++ b/app/tests.py
@@ -524,7 +524,7 @@ class TestAsciiDetailView(TestCase):
 
     def test_success(self):
         """
-        POST request right ascii_url_code should return 200
+        POST request with right ascii_url_code should return 200
         """
         obj = GeneratedASCII.objects.create(preferred_output_method='testing123')
         response = self.client.get(reverse('ascii_detail_url', kwargs={'ascii_url_code': obj.url_code}))
@@ -586,6 +586,18 @@ class TestAsciiDetailView(TestCase):
         self.assertNotIn('img2ascii chosen', response.content.decode('utf-8'))
         self.assertIn('txt2ascii chosen', response.content.decode('utf-8'))
         self.assertIn('checked', response.content.decode('utf-8'))
+        obj.delete()
+
+    def test_hidden(self):
+        """
+        POST request with right ascii_url_code, but with hidden status should return 404
+        """
+        obj = GeneratedASCII.objects.create(
+            preferred_output_method='testing123',
+            is_hidden=True
+        )
+        response = self.client.get(reverse('ascii_detail_url', kwargs={'ascii_url_code': obj.url_code}))
+        self.assertEqual(response.status_code, 404)
         obj.delete()
 
 

--- a/app/views.py
+++ b/app/views.py
@@ -99,7 +99,7 @@ def text_to_ascii_generator(request):
 
 
 def ascii_detail(request, ascii_url_code):
-    ascii_obj = GeneratedASCIIService.get_object_or_404(ascii_url_code)
+    ascii_obj = GeneratedASCIIService.get_active_object_or_404(ascii_url_code)
     app_txt_mode = GeneratedASCIIService.is_txt_mode(ascii_obj)
     return index_page(request, ascii_obj=ascii_obj, app_txt_mode=app_txt_mode)
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -28,7 +28,7 @@ if not os.path.exists(TEMPORARY_IMAGES):  # If temporary images folder is not ex
 
 # Import environment variables from python file if it exist. For local development only.
 if os.path.exists(os.path.join(BASE_DIR, 'project/env_vars.py')):
-    from . import env_vars
+    from . import env_vars  # noqa: F401
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv('SECRET_KEY')


### PR DESCRIPTION
- If generated ascii is having "is_hidden" field in `True`, you will not
be able to open it by link;
- If generated ascii is re-saved for some reason, it will not
re-generate it's url code as before;
- Admin page is now having related links between objects, search bars
for url_code and optimized raw_id_fields.